### PR TITLE
Handle Range as Part in mentionedRange

### DIFF
--- a/Source/Functions/src/ca/uqac/lif/petitpoucet/function/strings/Range.java
+++ b/Source/Functions/src/ca/uqac/lif/petitpoucet/function/strings/Range.java
@@ -199,7 +199,10 @@ public class Range implements Part, Comparable<Range>
 	/*@ null @*/ public static Range mentionedRange(Part d)
 	{
 		Range r = null;
-		if (d instanceof ComposedPart)
+		if(d instanceof Range){
+			r = (Range)d;
+		}
+		else if (d instanceof ComposedPart)
 		{
 			ComposedPart cd = (ComposedPart) d;
 			for (int i = cd.size() - 1; i >= 0; i--)

--- a/Source/Functions/srctest/ca/uqac/lif/petitpoucet/function/strings/RangeTest.java
+++ b/Source/Functions/srctest/ca/uqac/lif/petitpoucet/function/strings/RangeTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import ca.uqac.lif.petitpoucet.Part;
+
 /**
  * Unit tests for {@link Range}.
  */
@@ -94,5 +96,12 @@ public class RangeTest
 		boolean o = false;
 		assertEquals(o, r1.overlaps(r2));
 		assertEquals(o, r2.overlaps(r1));
+	}
+	
+	@Test
+	public void testMentionedRange()
+	{
+		Range r = new Range(3, 8);
+		assertEquals(r, Range.mentionedRange((Part)r));
 	}
 }


### PR DESCRIPTION
Textidote uses `Range` as `Part` directly. Using `Range.mentionedRange` fails in this case, which actually breaks the crawler class `RangeFetcher` in Textidote ([here](https://github.com/sylvainhalle/textidote/blob/master/Source/Core/src/ca/uqac/lif/textidote/as/RangeFetcher.java#L56)).